### PR TITLE
bugfix: fix the problem that image adapting in android device dint work

### DIFF
--- a/dist/vue-img.es6.js
+++ b/dist/vue-img.es6.js
@@ -32,10 +32,13 @@ const setAttr = (el, src, tag) => {
 
 const resize = (size) => {
   let viewWidth;
+  const dpr = window.devicePixelRatio;
+  const dataDpr = document.documentElement.getAttribute('data-dpr');
+  const ratio = dataDpr ? (dpr / dataDpr) : dpr;
+
   try {
     viewWidth = +(html.getAttribute('style').match(/(\d+)/) || [])[1];
   } catch(e) {
-    const dpr = window.devicePixelRatio;
     const w = html.offsetWidth;
     if (w / dpr > 540) {
       viewWidth = 540 * dpr / 10;
@@ -43,6 +46,8 @@ const resize = (size) => {
       viewWidth = w / 10;
     }
   }
+
+  viewWidth = viewWidth * ratio;
 
   if (Number(viewWidth) >= 0 && typeof viewWidth === 'number') {
     return (size * viewWidth) / 75 // 75 is the 1/10 iphone6 deivce width pixel

--- a/dist/vue-img.js
+++ b/dist/vue-img.js
@@ -42,10 +42,13 @@ var setAttr = function (el, src, tag) {
 
 var resize = function (size) {
   var viewWidth;
+  var dpr = window.devicePixelRatio;
+  var dataDpr = document.documentElement.getAttribute('data-dpr');
+  var ratio = dataDpr ? (dpr / dataDpr) : dpr;
+
   try {
     viewWidth = +(html.getAttribute('style').match(/(\d+)/) || [])[1];
   } catch(e) {
-    var dpr = window.devicePixelRatio;
     var w = html.offsetWidth;
     if (w / dpr > 540) {
       viewWidth = 540 * dpr / 10;
@@ -53,6 +56,8 @@ var resize = function (size) {
       viewWidth = w / 10;
     }
   }
+
+  viewWidth = viewWidth * ratio;
 
   if (Number(viewWidth) >= 0 && typeof viewWidth === 'number') {
     return (size * viewWidth) / 75 // 75 is the 1/10 iphone6 deivce width pixel

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,10 +19,13 @@ export const setAttr = (el, src, tag) => {
 
 export const resize = (size) => {
   let viewWidth
+  const dpr = window.devicePixelRatio
+  const dataDpr = document.documentElement.getAttribute('data-dpr')
+  const ratio = dataDpr ? (dpr / dataDpr) : dpr
+
   try {
     viewWidth = +(html.getAttribute('style').match(/(\d+)/) || [])[1]
   } catch(e) {
-    const dpr = window.devicePixelRatio
     const w = html.offsetWidth
     if (w / dpr > 540) {
       viewWidth = 540 * dpr / 10
@@ -30,6 +33,8 @@ export const resize = (size) => {
       viewWidth = w / 10
     }
   }
+
+  viewWidth = viewWidth * ratio
 
   if (Number(viewWidth) >= 0 && typeof viewWidth === 'number') {
     return (size * viewWidth) / 75 // 75 is the 1/10 iphone6 deivce width pixel


### PR DESCRIPTION
图片根据设备屏幕调整尺寸在安卓设备上有问题，因为lib-flexible 库将所有的安卓设备的 dpr 设置为了1.因此在安卓设备中，viewport 并没有做一个放大再缩小适配屏幕的步骤，在安卓设备中，html.getBoundingClientRect 的大小等于设备的独立像素。使得获取到的图片尺寸偏小。

代码对以上问题做了修正，详见代码。望大佬们再 review 下。